### PR TITLE
Kludge for respawning bug

### DIFF
--- a/datapacks/Pikmin_Origin/data/pikmin/powers/medium_size.json
+++ b/datapacks/Pikmin_Origin/data/pikmin/powers/medium_size.json
@@ -7,8 +7,12 @@
     },
     "entity_action_respawned":
     {
-        "type": "origins:execute_command",
-        "command": "function pikmin:medium"
+        "type": "origins:delay",
+        "ticks": 1,
+        "action": {
+            "type": "origins:execute_command",
+            "command": "function pikmin:medium"
+        }
     },
     "entity_action_lost":
     {

--- a/datapacks/Pikmin_Origin/data/pikmin/powers/rock_size.json
+++ b/datapacks/Pikmin_Origin/data/pikmin/powers/rock_size.json
@@ -7,8 +7,12 @@
     },
     "entity_action_respawned":
     {
-        "type": "origins:execute_command",
-        "command": "function pikmin:rock"
+        "type": "origins:delay",
+        "ticks": 1,
+        "action": {
+            "type": "origins:execute_command",
+            "command": "function pikmin:rock"
+        }
     },
     "entity_action_lost":
     {

--- a/datapacks/Pikmin_Origin/data/pikmin/powers/small_size.json
+++ b/datapacks/Pikmin_Origin/data/pikmin/powers/small_size.json
@@ -7,8 +7,12 @@
     },
     "entity_action_respawned":
     {
-        "type": "origins:execute_command",
-        "command": "function pikmin:small"
+        "type": "origins:delay",
+        "ticks": 1,
+        "action": {
+            "type": "origins:execute_command",
+            "command": "function pikmin:small"
+        }
     },
     "entity_action_lost":
     {

--- a/datapacks/Pikmin_Origin/data/pikmin/powers/tall_size.json
+++ b/datapacks/Pikmin_Origin/data/pikmin/powers/tall_size.json
@@ -7,8 +7,12 @@
     },
     "entity_action_respawned":
     {
-        "type": "origins:execute_command",
-        "command": "function pikmin:tall"
+        "type": "origins:delay",
+        "ticks": 1,
+        "action": {
+            "type": "origins:execute_command",
+            "command": "function pikmin:tall"
+        }
     },
     "entity_action_lost":
     {

--- a/datapacks/Pikmin_Origin/data/pikmin/powers/white_size.json
+++ b/datapacks/Pikmin_Origin/data/pikmin/powers/white_size.json
@@ -7,8 +7,12 @@
     },
     "entity_action_respawned":
     {
-        "type": "origins:execute_command",
-        "command": "function pikmin:white"
+        "type": "origins:delay",
+        "ticks": 1,
+        "action": {
+            "type": "origins:execute_command",
+            "command": "function pikmin:white"
+        }
     },
     "entity_action_lost":
     {


### PR DESCRIPTION
Pikmin origins were not scaling correctly upon respawning.  I have a hunch that Pehkui's scale reset upon respawning runs *after* Origins' respawn callback code runs, overwriting anything we were doing.  I'm not happy with this fix, but it works.